### PR TITLE
Handle allPages option being passed as string.

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -58,7 +58,7 @@ exports.onPostBuild = async (options, { allPages = false, paths = [], ...restPro
 		.map(({ path }) => path)
 		.filter((path) => path !== undefined && path !== DEV_PAGE && !fileRegexp.test(path));
 
-	if (allPages) {
+	if (allPages && allPages.toLowerCase() !== 'false') {
 		const promisses = pageNodes.map((pagePath) => generatePdf({ pagePath, ...restProps }));
 		await Promise.all(promisses);
 	} else {


### PR DESCRIPTION
Hello,

Thank you for sharing this plugin. I am using Gatsby 4.12.1. 

There seems to be a typecasting issue with the default value for the `onPostBuild` method `allPages` param.

This was being passed to the script as a string of `"false"` with this configuration. For what it's worth, omitting the `allPages: false` and relying on the default parameter value is broken as well without this fix.

```
    {
      resolve: "gatsby-plugin-pdf",
      options: {
        paths: ["/my-pdf/"],
        allPages: false,
        outputPath: "/public/exports",
      },
    },
```
