### PR TITLE
Allow override of Puppeteer browser

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -23,10 +23,12 @@ const generatePdf = async ({
   outputPath = 'public/exports',
   filePrefix,
   pdfOptions = {},
-  styleTagOptions
+  styleTagOptions,
+  browserPath
 }) => {
   const currentDir = process.cwd();
   const browser = await _puppeteer.default.launch({
+    executablePath: browserPath,
     headless: true
   });
   const page = await browser.newPage();
@@ -98,6 +100,7 @@ exports.pluginOptionsSchema = ({
       url: Joi.string().description(`URL of the <link> tag`),
       path: Joi.string().description(`Path to the CSS file to be injected into frame. If path is a relative path, then it is resolved relative to current working directory.`),
       content: Joi.string().description(`Raw CSS content to be injected into frame.`)
-    }).description(`See addStyleTag puppeteer options: https://github.com/puppeteer/puppeteer/blob/v5.5.0/docs/api.md#pageaddstyletagoptions.`)
+    }).description(`See addStyleTag puppeteer options: https://github.com/puppeteer/puppeteer/blob/v5.5.0/docs/api.md#pageaddstyletagoptions.`),
+    browserPath: Joi.string().description(`Optional path to preferred browser.`)
   });
 };

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -21,10 +21,14 @@ const generatePdf = async ({
 	outputPath = 'public/exports',
 	filePrefix,
 	pdfOptions = {},
-	styleTagOptions,
+    styleTagOptions,
+    browserPath,
 }) => {
 	const currentDir = process.cwd();
-	const browser = await puppeteer.launch({ headless: true });
+    const browser = await puppeteer.launch({
+      executablePath: browserPath,
+      headless: true,
+    });
 	const page = await browser.newPage();
 	const htmlPath = path.join(currentDir, 'public', pagePath, 'index.html');
 	const downloadDir = path.join(currentDir, outputPath);
@@ -102,5 +106,6 @@ exports.pluginOptionsSchema = ({ Joi }) => {
 		}).description(
 			`See addStyleTag puppeteer options: https://github.com/puppeteer/puppeteer/blob/v5.5.0/docs/api.md#pageaddstyletagoptions.`
 		),
+        browserPath: Joi.string().description(`Optional path to preferred browser.`),
 	});
 };


### PR DESCRIPTION
Creating a browser page via Puppeteer can hang on certain systems, as documented here: https://github.com/puppeteer/puppeteer/issues/4039

This change allows specifying a locally installed browser, resoving the issue.